### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/jqueryUiTreeControl/security/code-scanning/25](https://github.com/tarunbatta/jqueryUiTreeControl/security/code-scanning/25)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required. Since the workflow only needs to read repository contents, the `permissions` block should specify `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job.

The best approach is to add the `permissions` block at the root level of the workflow, as this ensures consistency and reduces redundancy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
